### PR TITLE
refactor(pilota-thrift-parser): add parser error and adapt pilota-build to the new api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
 dependencies = [
+ "concolor",
  "unicode-width",
  "yansi",
 ]
@@ -114,7 +115,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -131,6 +132,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -246,6 +253,26 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "concolor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b946244a988c390a94667ae0e3958411fa40cc46ea496a929b263d883f5f9c3"
+dependencies = [
+ "bitflags 1.3.2",
+ "concolor-query",
+ "is-terminal",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "criterion"
@@ -478,6 +505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,9 +560,20 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -786,7 +830,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -919,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-fieldmask"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ahash",
  "chumsky",
@@ -936,11 +980,13 @@ dependencies = [
 name = "pilota-thrift-parser"
 version = "0.12.2"
 dependencies = [
+ "anyhow",
  "ariadne",
  "bytes",
  "chumsky",
  "faststr",
  "nom",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1023,7 +1069,7 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
@@ -1213,7 +1259,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -1321,7 +1367,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1334,7 +1380,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -1968,11 +2014,20 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1981,7 +2036,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1995,19 +2050,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2017,9 +2093,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2035,9 +2123,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2047,9 +2147,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85.0"
 [workspace.dependencies]
 ahash = "0.8"
 anyhow = "1"
-ariadne = "0.5"
+ariadne = { version = "0.5", features = ["auto-color"] }
 async-recursion = "1"
 bytes = { version = "1", features = ["serde"] }
 chumsky = "0.10"

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -562,7 +562,7 @@ where
             mods.iter()
                 .map(|(mod_path, items)| {
                     let collect_has_direct = items
-                        .into_iter()
+                        .iter()
                         .into_group_map_by(|CodegenItem { def_id, .. }| {
                             self.node(*def_id).unwrap().file_id
                         })
@@ -651,7 +651,7 @@ where
             }
 
             if this.split {
-                Self::write_split_mod(this, base_dir, p, &def_ids, &mut stream, &mut dup);
+                Self::write_split_mod(this, base_dir, p, def_ids, &mut stream, &mut dup);
             } else {
                 for def_id in def_ids.iter() {
                     this.write_item(&mut stream, *def_id, &mut dup)

--- a/pilota-build/src/codegen/pb/mod.rs
+++ b/pilota-build/src/codegen/pb/mod.rs
@@ -81,9 +81,9 @@ impl ProtobufBackend {
 
                 if let ty::TyKind::Vec(_) = &ty.kind {
                     let encoded_len_fn = if is_arc {
-                        format!("::pilota::pb::encoding::arc_message::encoded_len_repeated")
+                        "::pilota::pb::encoding::arc_message::encoded_len_repeated"
                     } else {
-                        format!("::pilota::pb::encoding::message::encoded_len_repeated")
+                        "::pilota::pb::encoding::message::encoded_len_repeated"
                     };
 
                     match kind {
@@ -671,9 +671,9 @@ impl CodegenBackend for ProtobufBackend {
                         .collect::<Vec<_>>()
                         .join("::");
                     if pkg == "google::protobuf" {
-                        deps_builders.push_str(&format!(
-                            "deps.push(::pilota::pb::descriptor::file_descriptor().clone());\n"
-                        ));
+                        deps_builders.push_str(
+                            "deps.push(::pilota::pb::descriptor::file_descriptor().clone());\n",
+                        );
                     } else if has_include_path && !pkg.is_empty() {
                         let dep_filename = self
                             .file_paths()

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -773,7 +773,7 @@ impl Parser for ProtobufParser {
             files,
             input_files: input_file_ids,
             file_ids_map: file_ids,
-            file_paths: file_paths,
+            file_paths,
         }
     }
 }

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -1,8 +1,6 @@
 use core::panic;
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
-use ariadne::{Color, Label, Report, ReportKind, Source};
-use chumsky::prelude::*;
 use faststr::FastStr;
 use heck::ToUpperCamelCase;
 use itertools::Itertools;
@@ -42,26 +40,14 @@ impl ThriftSourceDatabase {
 
     fn parse(&self, path: PathBuf) -> Arc<thrift_parser::File> {
         let text = self.file_text(path.clone());
-        let (res, errs) = thrift_parser::descriptor::File::parse()
-            .parse(&text)
-            .into_output_errors();
+        let res = thrift_parser::FileParser::new(
+            thrift_parser::FileSource::new_with_path(path.clone(), text.as_ref()).unwrap(),
+        )
+        .parse();
 
-        let path_str = &path.display().to_string();
-        if !errs.is_empty() {
-            errs.into_iter().for_each(|e| {
-                Report::build(ReportKind::Error, (path_str, e.span().into_range()))
-                    .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
-                    .with_message(e.to_string())
-                    .with_label(
-                        Label::new((path_str, e.span().into_range()))
-                            .with_message(e.reason().to_string())
-                            .with_color(Color::Red),
-                    )
-                    .finish()
-                    .print((path_str, Source::from(&text)))
-                    .unwrap()
-            });
-            panic!("thrift file parse failed");
+        if res.is_err() {
+            eprintln!("{}", res.err().unwrap());
+            std::process::exit(1);
         }
 
         let mut ast = res.unwrap();

--- a/pilota-thrift-fieldmask/Cargo.toml
+++ b/pilota-thrift-fieldmask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-fieldmask"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-fieldmask/src/fieldmask.rs
+++ b/pilota-thrift-fieldmask/src/fieldmask.rs
@@ -1644,9 +1644,15 @@ mod tests {
     #[test]
     fn test_get_path() {
         let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
-        let mut ast = pilota_thrift_parser::descriptor::File::parse()
-            .parse(&content)
-            .unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/fieldmask.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/fieldmask.thrift")
                 .canonicalize()
@@ -1657,9 +1663,15 @@ mod tests {
         pilota_thrift_reflect::service::Register::register(key, desc.clone());
 
         let content = std::fs::read_to_string("../examples/idl/base.thrift").unwrap();
-        let mut ast = pilota_thrift_parser::descriptor::File::parse()
-            .parse(&content)
-            .unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/base.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/base.thrift")
                 .canonicalize()

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -18,8 +18,10 @@ keywords = ["serialization", "thrift", "parser"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-nom.workspace = true
-bytes.workspace = true
-faststr.workspace = true
-chumsky.workspace = true
+anyhow.workspace = true
 ariadne.workspace = true
+bytes.workspace = true
+chumsky.workspace = true
+faststr.workspace = true
+nom.workspace = true
+thiserror.workspace = true

--- a/pilota-thrift-parser/src/lib.rs
+++ b/pilota-thrift-parser/src/lib.rs
@@ -7,3 +7,7 @@ pub mod descriptor;
 pub mod parser;
 
 pub use descriptor::*;
+pub use parser::{
+    error::Error,
+    thrift::{FileParser, FileSource},
+};

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 impl Annotation {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
         let key = Ident::ident_with_dot();
 
         let value = Literal::parse();
@@ -33,7 +33,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_annotations() {
-        let _a = Annotation::parse()
+        let _a = Annotation::get_parser()
             .parse(r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"")"#)
             .unwrap();
 
@@ -42,7 +42,7 @@ mod tests {
             python.type ="DenseFoo",
             java.final="",
             )"#;
-        let res = Annotation::parse().parse(input).unwrap();
+        let res = Annotation::get_parser().parse(input).unwrap();
         assert_eq!(res.len(), 3);
     }
 }

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -7,8 +7,8 @@ use super::super::{
 use crate::{Annotation, IntConstant};
 
 impl EnumValue {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
-        Ident::parse()
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
+        Ident::get_parser()
             .padded_by(blank().or_not())
             .then(
                 just("=")
@@ -17,7 +17,7 @@ impl EnumValue {
                     .or_not(),
             )
             .then_ignore(blank().or_not())
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(|((name, value), annotations)| EnumValue {
                 name: Ident(name.into()),
@@ -28,17 +28,17 @@ impl EnumValue {
 }
 
 impl Enum {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Enum, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Enum, extra::Err<Rich<'a, char>>> {
         just("enum")
             .ignore_then(blank())
-            .ignore_then(Ident::parse())
+            .ignore_then(Ident::get_parser())
             .then_ignore(blank().or_not())
             .then_ignore(just("{"))
-            .then(EnumValue::parse().repeated().collect())
+            .then(EnumValue::get_parser().repeated().collect())
             .then_ignore(blank().or_not())
             .then_ignore(just("}"))
             .then_ignore(blank().or_not())
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .map(|((name, values), annotations)| Enum {
                 name: Ident(name.into()),
                 values,
@@ -52,7 +52,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_enum() {
-        let _ = Enum::parse()
+        let _ = Enum::get_parser()
             .parse(
                 r#"enum Sex {
                             UNKNOWN = 0,
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_enum2() {
-        let _ = Enum::parse()
+        let _ = Enum::get_parser()
             .parse(
                 r#"enum Index {
                             A = 0x01,

--- a/pilota-thrift-parser/src/parser/error.rs
+++ b/pilota-thrift-parser/src/parser/error.rs
@@ -1,0 +1,28 @@
+use faststr::FastStr;
+
+#[derive(thiserror::Error)]
+pub enum Error {
+    #[error("IO error: {0}")]
+    IO(std::io::Error),
+    #[error("File not found: {0}")]
+    FileNotFound(std::path::PathBuf),
+    #[error("Syntax error: {source}")]
+    Syntax {
+        summary: FastStr,
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+// for unwrap
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Syntax { summary, .. } => {
+                write!(f, "{}", summary)
+            }
+            Error::IO(error) => write!(f, "{}", error),
+            Error::FileNotFound(path_buf) => write!(f, "{}", path_buf.display()),
+        }
+    }
+}

--- a/pilota-thrift-parser/src/parser/function.rs
+++ b/pilota-thrift-parser/src/parser/function.rs
@@ -8,8 +8,8 @@ use super::super::{
 use crate::{Annotation, Field, Type, parser::*};
 
 impl Function {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Function, extra::Err<Rich<'a, char>>> {
-        let fields = Field::parse()
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Function, extra::Err<Rich<'a, char>>> {
+        let fields = Field::get_parser()
             .padded_by(blank().or_not())
             .repeated()
             .at_least(1)
@@ -26,16 +26,16 @@ impl Function {
         just("oneway")
             .then_ignore(blank())
             .or_not()
-            .then(Type::parse())
+            .then(Type::get_parser())
             .then_ignore(blank())
-            .then(Ident::parse())
+            .then(Ident::get_parser())
             .then_ignore(just("(").padded_by(blank().or_not()))
             .then(fields.clone().or_not())
             .then_ignore(just(")"))
             .padded_by(blank().or_not())
             .then(throws.or_not())
             .then_ignore(blank().or_not())
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(
                 |(((((oneway, r#type), name), arguments), throws), annotations)| {
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_func() {
-        let _f = Function::parse()
+        let _f = Function::get_parser()
             .parse(
                 r#"map<i64, shared.ProcessingStatus> processUserData(
                             1: required list<UserProfile> profiles,
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_func2() {
-        let _f = Function::parse()
+        let _f = Function::get_parser()
             .parse(
                 r#"oneway void pingServer(
                             1: required string(go.tag = 'json:"source_service"') source,
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn test_func3() {
-        let _f = Function::parse()
+        let _f = Function::get_parser()
             .parse(r#"Err test_enum_var_type_name_conflict (1: Request req);"#)
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/identifier.rs
+++ b/pilota-thrift-parser/src/parser/identifier.rs
@@ -3,7 +3,7 @@ use chumsky::prelude::*;
 use crate::Ident;
 
 impl Ident {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
         text::ascii::ident().map(|ident: &str| ident.to_string())
     }
 
@@ -27,12 +27,12 @@ mod test {
 
     #[test]
     fn test_identifier() {
-        assert_eq!(Ident::parse().parse("abc").unwrap(), "abc");
-        assert_eq!(Ident::parse().parse("a1d").unwrap(), "a1d");
-        assert_eq!(Ident::parse().parse("foo_bar").unwrap(), "foo_bar");
+        assert_eq!(Ident::get_parser().parse("abc").unwrap(), "abc");
+        assert_eq!(Ident::get_parser().parse("a1d").unwrap(), "a1d");
+        assert_eq!(Ident::get_parser().parse("foo_bar").unwrap(), "foo_bar");
 
-        assert_eq!(Ident::parse().parse("_123").unwrap(), "_123");
-        assert_eq!(Ident::parse().parse("_").unwrap(), "_");
+        assert_eq!(Ident::get_parser().parse("_123").unwrap(), "_123");
+        assert_eq!(Ident::get_parser().parse("_").unwrap(), "_");
     }
 
     #[test]

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -7,7 +7,7 @@ use super::super::{
 use crate::Literal;
 
 impl Include {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
         just("include")
             .ignore_then(blank())
             .ignore_then(Literal::parse())
@@ -24,7 +24,7 @@ impl CppInclude {
             .ignore_then(Literal::parse())
             .then_ignore(blank().or_not())
             .then_ignore(list_separator().or_not())
-            .map(|path| CppInclude(path))
+            .map(CppInclude)
     }
 }
 
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn test_include() {
-        let _f = Include::parse()
+        let _f = Include::get_parser()
             .parse(r#"include "shared.thrift""#)
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -5,6 +5,7 @@
 mod annotation;
 mod constant;
 mod enum_;
+pub mod error;
 mod field;
 mod function;
 mod identifier;
@@ -24,7 +25,7 @@ use crate::Ident;
 
 impl Path {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, Path, extra::Err<Rich<'a, char>>> {
-        Ident::parse()
+        Ident::get_parser()
             .separated_by(just('.').padded_by(blank()))
             .at_least(1)
             .collect()

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -4,11 +4,15 @@ use super::super::parser::*;
 use crate::{Annotation, Namespace, Scope};
 
 impl Namespace {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
         just("namespace")
             .ignore_then(Scope::parse().padded_by(blank()))
             .then(Path::parse())
-            .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+            .then(
+                Annotation::get_parser()
+                    .or_not()
+                    .padded_by(blank().or_not()),
+            )
             .then_ignore(list_separator().or_not())
             .map(|((scope, name), annotations)| Namespace {
                 scope,
@@ -39,8 +43,10 @@ mod tests {
 
     #[test]
     fn test_namespace() {
-        let _ = Namespace::parse().parse("namespace * foo.bar").unwrap();
-        let _ = Namespace::parse()
+        let _ = Namespace::get_parser()
+            .parse("namespace * foo.bar")
+            .unwrap();
+        let _ = Namespace::get_parser()
             .parse("namespace py.twisted ThriftTest")
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/service.rs
+++ b/pilota-thrift-parser/src/parser/service.rs
@@ -4,25 +4,25 @@ use super::super::{descriptor::Service, parser::*};
 use crate::{Annotation, Function, Ident};
 
 impl Service {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Service, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Service, extra::Err<Rich<'a, char>>> {
         let extends = just("extends")
             .padded_by(blank())
             .ignore_then(Path::parse());
         let functions = blank()
             .or_not()
-            .ignore_then(Function::parse())
+            .ignore_then(Function::get_parser())
             .repeated()
             .collect::<Vec<_>>();
 
         just("service")
             .ignore_then(blank())
-            .ignore_then(Ident::parse())
+            .ignore_then(Ident::get_parser())
             .then(extends.or_not())
             .then_ignore(blank().or_not())
             .then_ignore(just("{"))
             .then(functions)
             .then_ignore(just("}").padded_by(blank().or_not()))
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(|(((name, extends), functions), annotations)| Service {
                 name: Ident(name.into()),
@@ -38,7 +38,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_service() {
-        let _ = Service::parse().parse(
+        let _ = Service::get_parser().parse(
             r#"service ComplexService {
 
                         /**
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn test_service2() {
-        let _ = Service::parse()
+        let _ = Service::get_parser()
             .parse(
                 r#"service Test {
                             Err test_enum(1: Ok req);

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -7,7 +7,7 @@ use super::super::{
 use crate::{Annotation, Field, Ident};
 
 impl Struct {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Struct, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Struct, extra::Err<Rich<'a, char>>> {
         just("struct")
             .ignore_then(blank())
             .ignore_then(StructLike::parse())
@@ -35,17 +35,17 @@ impl Exception {
 
 impl StructLike {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, StructLike, extra::Err<Rich<'a, char>>> {
-        Ident::parse()
+        Ident::get_parser()
             .then_ignore(blank().or_not())
             .then_ignore(just("{"))
             .then(
                 blank()
-                    .ignore_then(Field::parse())
+                    .ignore_then(Field::get_parser())
                     .repeated()
                     .collect::<Vec<_>>(),
             )
             .then_ignore(just("}").padded_by(blank().or_not()))
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(|((name, fields), annotations)| StructLike {
                 name: Ident(name.into()),
@@ -72,7 +72,7 @@ mod tests {
         }
         "#;
 
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 
     #[test]
@@ -81,7 +81,7 @@ mod tests {
             // 1
         }
         "#;
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 
     #[test]
@@ -90,7 +90,7 @@ mod tests {
             1: string user_id (go.tag = 'json:\"user_id,omitempty\"'),
             2: string __files (go.tag = 'json:\"__files,omitempty\"'),
         }"#;
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 
     #[test]
@@ -99,6 +99,6 @@ mod tests {
             1: required string(pilota.annotation="test") Service,      // required service
             2: required bytet_i.Injection Injection,
         }"#;
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/thrift.rs
+++ b/pilota-thrift-parser/src/parser/thrift.rs
@@ -1,29 +1,193 @@
+use std::path::PathBuf;
+
+use ariadne::{Color, Label, Report, ReportKind, Source};
 use chumsky::prelude::*;
+use faststr::FastStr;
 
 use super::super::{descriptor::File, parser::*};
 use crate::{
-    Constant, CppInclude, Enum, Exception, Include, Item, Namespace, Service, Struct, Union,
+    Constant, CppInclude, Enum, Exception, Include, Item, Namespace, Service, Struct, Typedef,
+    Union,
 };
 
 impl Item {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, Item, extra::Err<Rich<'a, char>>> {
         choice((
-            Include::parse().map(Item::Include),
+            Include::get_parser().map(Item::Include),
             CppInclude::parse().map(Item::CppInclude),
-            Namespace::parse().map(Item::Namespace),
-            typedef::type_def().map(Item::Typedef),
-            Constant::parse().map(Item::Constant),
-            Enum::parse().map(Item::Enum),
-            Struct::parse().map(Item::Struct),
+            Namespace::get_parser().map(Item::Namespace),
+            Typedef::get_parser().map(Item::Typedef),
+            Constant::get_parser().map(Item::Constant),
+            Enum::get_parser().map(Item::Enum),
+            Struct::get_parser().map(Item::Struct),
             Union::parse().map(Item::Union),
             Exception::parse().map(Item::Exception),
-            Service::parse().map(Item::Service),
+            Service::get_parser().map(Item::Service),
         ))
     }
 }
 
+pub struct FileSource<'a> {
+    path: Option<PathBuf>,
+    content: &'a str,
+}
+
+impl<'a> FileSource<'a> {
+    pub fn new(inline: &'a str) -> Self {
+        Self {
+            path: None,
+            content: inline,
+        }
+    }
+
+    pub fn new_with_path(path: PathBuf, content: &'a str) -> Result<Self, error::Error> {
+        if !path.exists() {
+            return Err(error::Error::FileNotFound(path));
+        }
+
+        Ok(Self {
+            path: Some(path),
+            content,
+        })
+    }
+}
+
+pub struct FileParser<'a> {
+    pub source: FileSource<'a>,
+}
+
+impl<'a> FileParser<'a> {
+    pub fn new(source: FileSource<'a>) -> Self {
+        Self { source }
+    }
+
+    pub fn parse(&self) -> Result<File, error::Error> {
+        let (ast, errs) = File::get_parser()
+            .parse(self.source.content)
+            .into_output_errors();
+
+        let path_str = match &self.source.path {
+            Some(path) => &path.display().to_string(),
+            None => "inline",
+        };
+
+        if !errs.is_empty() {
+            let mut report_strings = Vec::with_capacity(errs.len() + 1);
+
+            let title = if errs.len() == 1 {
+                format!("Failed to parse thrift file: {}", path_str)
+            } else {
+                format!(
+                    "Failed to parse thrift file: {} ({} errors found)",
+                    path_str,
+                    errs.len()
+                )
+            };
+            report_strings.push(title);
+            report_strings.push(String::new());
+
+            for (i, e) in errs.iter().enumerate() {
+                if errs.len() > 1 {
+                    let error_header = format!("Error {}:", i + 1);
+                    report_strings.push(error_header.clone());
+                }
+
+                let mut buffer = Vec::new();
+                Report::build(ReportKind::Error, (path_str, e.span().into_range()))
+                    .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
+                    .with_message(e.to_string())
+                    .with_label(
+                        Label::new((path_str, e.span().into_range()))
+                            .with_message(e.reason().to_string())
+                            .with_color(Color::Red),
+                    )
+                    .finish()
+                    .write((path_str, Source::from(self.source.content)), &mut buffer)
+                    .unwrap();
+                report_strings.push(String::from_utf8_lossy(&buffer).to_string());
+
+                if i < errs.len() - 1 {
+                    report_strings.push(String::new());
+                }
+            }
+
+            let report = report_strings.join("\n").into();
+            let summary = create_error_summary(&errs, path_str, self.source.content).into();
+            let custom_error = CustomSyntaxError { report };
+
+            return Err(error::Error::Syntax {
+                summary,
+                source: anyhow::anyhow!(custom_error),
+            });
+        }
+
+        Ok(ast.unwrap())
+    }
+}
+
+fn create_error_summary(errs: &[chumsky::error::Rich<char>], path_str: &str, text: &str) -> String {
+    if errs.is_empty() {
+        return String::new();
+    }
+
+    let mut summary = format!("Failed to parse thrift file: {}", path_str);
+
+    if errs.len() == 1 {
+        let err = &errs[0];
+        // 计算行号和列号
+        let (line, col) = calculate_line_col(err.span().start, text);
+        summary.push_str(&format!(" at line {}:{} - {}", line, col, err.reason()));
+    } else {
+        summary.push_str(&format!(" ({} errors found):", errs.len()));
+        for (i, err) in errs.iter().enumerate() {
+            let (line, col) = calculate_line_col(err.span().start, text);
+            summary.push_str(&format!(
+                "\n  {}. Line {}:{} - {}",
+                i + 1,
+                line,
+                col,
+                err.reason()
+            ));
+        }
+    }
+
+    summary
+}
+
+fn calculate_line_col(pos: usize, text: &str) -> (usize, usize) {
+    let mut line = 1;
+    let mut col = 1;
+
+    for (i, ch) in text.char_indices() {
+        if i >= pos {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+
+    (line, col)
+}
+
+#[derive(Debug)]
+pub struct CustomSyntaxError {
+    pub report: FastStr,
+}
+
+impl std::fmt::Display for CustomSyntaxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.report)
+    }
+}
+
+impl std::error::Error for CustomSyntaxError {}
+
 impl File {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, File, extra::Err<Rich<'a, char>>> {
+    pub(crate) fn get_parser<'a>() -> impl Parser<'a, &'a str, File, extra::Err<Rich<'a, char>>> {
         let item_or_none = blank()
             .or_not()
             .ignore_then(Item::parse())
@@ -35,9 +199,10 @@ impl File {
             .then_ignore(blank().or_not())
             .then_ignore(end())
             .map(|items: Vec<Item>| {
-                let mut file = File::default();
-
-                file.items = items;
+                let mut file = File {
+                    items,
+                    ..Default::default()
+                };
 
                 let mut namespaces = file.items.iter().filter_map(|i| match i {
                     Item::Namespace(ns) => Some(ns),
@@ -138,7 +303,7 @@ mod tests {
             BizResponse BizMethod3(1: BizRequest req)(api.post = '/life/client/:action/:biz/other', api.baseurl = 'ib.snssdk.com', api.param = 'true', api.serializer = 'json')
         }
         "#;
-        let (file, errs) = File::parse().parse(body).into_output_errors();
+        let (file, errs) = File::get_parser().parse(body).into_output_errors();
         println!("{file:#?}");
         errs.into_iter().for_each(|e| {
             Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))
@@ -177,7 +342,7 @@ const list<string> TEST_LIST = [
 service Service {
   MyStruct testEpisode(1:MyStruct arg)
 },"#;
-        let (file, errs) = File::parse().parse(body).into_output_errors();
+        let (file, errs) = File::get_parser().parse(body).into_output_errors();
         println!("{file:#?}");
         errs.into_iter().for_each(|e| {
             Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))
@@ -202,7 +367,7 @@ service Service {
 
         # comment 2
         "#;
-        let (file, errs) = File::parse().parse(body).into_output_errors();
+        let (file, errs) = File::get_parser().parse(body).into_output_errors();
         println!("{file:#?}");
         errs.into_iter().for_each(|e| {
             Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -18,7 +18,7 @@ impl CppType {
 }
 
 impl Type {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Type, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Type, extra::Err<Rich<'a, char>>> {
         recursive(|self_parser| {
             let base_ty = choice((
                 just("string").to(Ty::String),
@@ -78,7 +78,11 @@ impl Type {
             let ty_parser = choice((base_ty, list, set, map_parser, Path::parse().map(Ty::Path)));
 
             ty_parser
-                .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+                .then(
+                    Annotation::get_parser()
+                        .or_not()
+                        .padded_by(blank().or_not()),
+                )
                 .map(|(ty, an)| Type(ty, an.unwrap_or_default()))
                 .boxed()
         })
@@ -94,14 +98,14 @@ mod tests {
 
     #[test]
     fn test_type() {
-        let parser = Type::parse();
+        let parser = Type::get_parser();
         let input = "map<i32, string>";
         let _res = parser.parse(input).unwrap();
     }
 
     #[test]
     fn test_type_path() {
-        let parser = Type::parse();
+        let parser = Type::get_parser();
         let input = "bytet_i.Injection";
         let _res = parser.parse(input).unwrap();
     }

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -3,18 +3,20 @@ use chumsky::prelude::*;
 use super::super::{descriptor::Typedef, parser::*};
 use crate::{Annotation, Type, descriptor::Ident};
 
-pub fn type_def<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
-    just("typedef")
-        .ignore_then(Type::parse().padded_by(blank()))
-        .then(Ident::parse())
-        .then_ignore(blank().or_not())
-        .then(Annotation::parse().or_not())
-        .then_ignore(list_separator().or_not())
-        .map(|((r#type, alias), annotations)| Typedef {
-            r#type,
-            alias: Ident(alias.into()),
-            annotations: annotations.unwrap_or_default(),
-        })
+impl Typedef {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
+        just("typedef")
+            .ignore_then(Type::get_parser().padded_by(blank()))
+            .then(Ident::get_parser())
+            .then_ignore(blank().or_not())
+            .then(Annotation::get_parser().or_not())
+            .then_ignore(list_separator().or_not())
+            .map(|((r#type, alias), annotations)| Typedef {
+                r#type,
+                alias: Ident(alias.into()),
+                annotations: annotations.unwrap_or_default(),
+            })
+    }
 }
 
 #[cfg(test)]
@@ -23,6 +25,6 @@ mod tests {
 
     #[test]
     fn test_type_def() {
-        let _td = type_def().parse("typedef i32 Int32,").unwrap();
+        let _td = Typedef::get_parser().parse("typedef i32 Int32,").unwrap();
     }
 }

--- a/pilota-thrift-reflect/examples/idl/apache.thrift
+++ b/pilota-thrift-reflect/examples/idl/apache.thrift
@@ -63,8 +63,7 @@ const Numberz myNumberz = Numberz.ONE;
 
 typedef i64 UserId
 
-struct Bonk
-{
+struct Bonk {
   1: string message,
   2: i32 type
 }

--- a/pilota-thrift-reflect/examples/main.rs
+++ b/pilota-thrift-reflect/examples/main.rs
@@ -9,9 +9,22 @@ fn main() {
     println!("{}", idl_path.display());
 
     let content = std::fs::read_to_string(&idl_path).unwrap();
-    let mut parsed_file = pilota_thrift_parser::descriptor::File::parse()
-        .parse(&content)
-        .unwrap();
+    let ret = pilota_thrift_parser::parser::thrift::FileParser::new(
+        pilota_thrift_parser::FileSource::new_with_path(idl_path.clone(), &content).unwrap(),
+    )
+    .parse();
+    let mut parsed_file = match ret {
+        Ok(parsed_file) => parsed_file,
+        Err(e) => {
+            eprintln!("{}", e);
+            return;
+        }
+    };
+    // let mut parsed_file =
+    // pilota_thrift_parser::parser::thrift::FileParser::new(idl_path.clone())
+    //     .parse()
+    //     .unwrap();
+
     parsed_file.path = idl_path.into();
 
     let descriptor: pilota_thrift_reflect::thrift_reflection::FileDescriptor =

--- a/pilota/src/pb/extension.rs
+++ b/pilota/src/pb/extension.rs
@@ -81,7 +81,7 @@ impl OptionValueExtractor for UInt64OptionValueExtractor {
     type Value = u64;
     fn get_from_unknown(value: protobuf::UnknownValueRef) -> Result<Self::Value, DecodeError> {
         match value {
-            protobuf::UnknownValueRef::Varint(v) => Ok(v as u64),
+            protobuf::UnknownValueRef::Varint(v) => Ok(v),
             _ => Err(DecodeError::new("invalid value for u64")),
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
As a parser library, we need to encapsulate our own errors. The goal is to provide basic error types and good error representations. At the same time, considering maintainability, we use anyhow error to package the errors of internally dependent third-party libraries.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
First, define our error types, including path errors, IO errors, and syntax errors. It is worth noting that we need to do some packaging for the errors of the text processors we rely on to reduce the impact on the user interface when replacing dependencies or refactoring.

Second, consider that our errors may be unwrapped directly, output to std, or redirected to a file, so make sure these methods are displayed in a friendly way.

