### PR TITLE
Feat/codegen with comments

### DIFF
--- a/pilota-build/examples/salsa_cache_demo.rs
+++ b/pilota-build/examples/salsa_cache_demo.rs
@@ -30,8 +30,10 @@ fn main() {
 
     // Create a service item
     let service = rir::Item::Service(rir::Service {
+        comments: Arc::new(String::new()),
         name: "TestService".into(),
         methods: vec![Arc::new(Method {
+            comments: Arc::new(String::new()),
             def_id: DefId::from_u32(1),
             name: "method1".into(),
             args: vec![],

--- a/pilota-build/src/ir/mod.rs
+++ b/pilota-build/src/ir/mod.rs
@@ -102,6 +102,7 @@ pub struct ExceptionVariant {
 
 #[derive(Clone, Debug)]
 pub struct Method {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub args: Vec<Arg>,
     pub ret: Ty,
@@ -112,6 +113,7 @@ pub struct Method {
 
 #[derive(Clone, Debug)]
 pub struct Service {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub methods: Vec<Method>,
     pub extend: Vec<Path>,
@@ -119,6 +121,7 @@ pub struct Service {
 
 #[derive(Clone, Debug)]
 pub struct Const {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub ty: Ty,
     pub lit: Literal,
@@ -132,6 +135,7 @@ pub enum FieldKind {
 
 #[derive(Clone, Debug)]
 pub struct Field {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub id: i32,
     pub ty: Ty,
@@ -142,6 +146,7 @@ pub struct Field {
 
 #[derive(Clone, Debug)]
 pub struct Message {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub fields: Vec<Field>,
     pub is_wrapper: bool,
@@ -150,6 +155,7 @@ pub struct Message {
 
 #[derive(Clone, Debug)]
 pub struct EnumVariant {
+    pub comments: Arc<String>,
     pub id: Option<i32>,
     pub name: Ident,
     pub discr: Option<i64>,
@@ -159,6 +165,7 @@ pub struct EnumVariant {
 
 #[derive(Clone, Debug)]
 pub struct Enum {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub variants: Vec<EnumVariant>,
     pub repr: Option<EnumRepr>,
@@ -166,6 +173,7 @@ pub struct Enum {
 
 #[derive(Clone, Debug)]
 pub struct NewType {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub ty: Ty,
 }

--- a/pilota-build/src/middle/rir.rs
+++ b/pilota-build/src/middle/rir.rs
@@ -78,6 +78,7 @@ pub enum MethodSource {
 }
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Method {
+    pub comments: Arc<String>,
     pub def_id: DefId,
     pub name: Ident,
     pub args: Vec<Arc<Arg>>,
@@ -89,6 +90,7 @@ pub struct Method {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Service {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub methods: Vec<Arc<Method>>,
     pub extend: Vec<Path>,
@@ -96,6 +98,7 @@ pub struct Service {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Const {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub ty: Ty,
     pub lit: Literal,
@@ -109,6 +112,7 @@ pub enum FieldKind {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Field {
+    pub comments: Arc<String>,
     pub did: DefId,
     pub name: Ident,
     pub id: i32,
@@ -130,6 +134,7 @@ impl Field {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Message {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub fields: Vec<Arc<Field>>,
     pub is_wrapper: bool,
@@ -138,6 +143,7 @@ pub struct Message {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EnumVariant {
+    pub comments: Arc<String>,
     pub id: Option<i32>,
     pub did: DefId,
     pub name: Ident,
@@ -147,6 +153,7 @@ pub struct EnumVariant {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Enum {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub variants: Vec<Arc<EnumVariant>>,
     pub repr: Option<EnumRepr>,
@@ -154,6 +161,7 @@ pub struct Enum {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct NewType {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub ty: Ty,
 }

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -230,11 +230,13 @@ impl Lower {
             related_items: Default::default(),
             tags: Arc::new(self.extract_enum_tags(e)),
             kind: ir::ItemKind::Enum(ir::Enum {
+                comments: Arc::new(String::new()),
                 name: FastStr::new(e.name()).into(),
                 variants: e
                     .value
                     .iter()
                     .map(|v| ir::EnumVariant {
+                        comments: Arc::new(String::new()),
                         id: v.number,
                         name: FastStr::new(v.name()).into(),
                         discr: v.number.map(|v| v as i64),
@@ -299,11 +301,13 @@ impl Lower {
                     related_items: Default::default(),
                     tags: Arc::new(crate::tags!(OneOf)),
                     kind: ir::ItemKind::Enum(ir::Enum {
+                        comments: Arc::new(String::new()),
                         name: FastStr::new(d.name()).into(),
                         repr: None,
                         variants: fields
                             .iter()
                             .map(|(_, f)| ir::EnumVariant {
+                                comments: Arc::new(String::new()),
                                 discr: None,
                                 id: f.number,
                                 name: FastStr::new(f.name()).into(),
@@ -322,6 +326,7 @@ impl Lower {
                 extra_fields.push((
                     fields[0].0,
                     ir::Field {
+                        comments: Arc::new(String::new()),
                         name: FastStr::new(d.name()).into(),
                         id: -1,
                         ty: ir::Ty {
@@ -363,6 +368,7 @@ impl Lower {
             related_items: Default::default(),
             tags: Arc::new(self.extract_message_tags(message)),
             kind: ir::ItemKind::Message(ir::Message {
+                comments: Arc::new(String::new()),
                 fields: fields
                     .iter()
                     .map(|(idx, f)| {
@@ -401,6 +407,7 @@ impl Lower {
                         (
                             *idx,
                             ir::Field {
+                                comments: Arc::new(String::new()),
                                 default: None,
                                 id: f.number(),
                                 name: FastStr::new(f.name()).into(),
@@ -461,6 +468,7 @@ impl Lower {
             tags: Arc::new(service_tags),
             related_items: Default::default(),
             kind: ir::ItemKind::Service(ir::Service {
+                comments: Arc::new(String::new()),
                 name: FastStr::new(service.name()).into(),
                 methods: service
                     .method
@@ -480,6 +488,7 @@ impl Lower {
                         }
 
                         ir::Method {
+                            comments: Arc::new(String::new()),
                             name: FastStr::new(m.name()).into(),
                             tags: Arc::new(tags),
                             args: vec![ir::Arg {
@@ -580,6 +589,7 @@ impl Lower {
                         related_items: Default::default(),
                         tags: Arc::new(Tags::default()),
                         kind: ir::ItemKind::Const(ir::Const {
+                            comments: Arc::new(String::new()),
                             name: FastStr::new(format!("__PILOTA_PB_EXT_{}", file_id.as_u32()))
                                 .into(),
                             ty: ir::Ty {

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -375,7 +375,10 @@ impl Resolver {
             kind = FieldKind::Optional;
         }
 
+        let comments = f.comments.clone();
+
         let f = Arc::from(Field {
+            comments,
             did,
             id: f.id,
             kind,
@@ -592,6 +595,7 @@ impl Resolver {
     #[tracing::instrument(level = "debug", skip(self, s), fields(name = &**s.name))]
     fn lower_message(&mut self, s: &ir::Message) -> Message {
         Message {
+            comments: s.comments.clone(),
             name: s.name.clone(),
             fields: s.fields.iter().map(|f| self.lower_field(f)).collect(),
             is_wrapper: s.is_wrapper,
@@ -606,6 +610,7 @@ impl Resolver {
     fn lower_enum(&mut self, e: &ir::Enum) -> Enum {
         let mut next_discr = 0;
         Enum {
+            comments: e.comments.clone(),
             name: e.name.clone(),
             variants: e
                 .variants
@@ -618,6 +623,7 @@ impl Resolver {
                     }
                     let discr = v.discr.unwrap_or(next_discr);
                     let e = Arc::from(EnumVariant {
+                        comments: v.comments.clone(),
                         id: v.id,
                         did,
                         name: v.name.clone(),
@@ -647,6 +653,7 @@ impl Resolver {
 
     fn lower_service(&mut self, s: &ir::Service) -> Service {
         Service {
+            comments: s.comments.clone(),
             name: s.name.clone(),
             methods: s
                 .methods
@@ -657,6 +664,7 @@ impl Resolver {
                     self.tags.insert(tags_id, m.tags.clone());
                     let old_parent = self.parent_node.replace(def_id);
                     let method = Arc::from(Method {
+                        comments: m.comments.clone(),
                         def_id,
                         source: MethodSource::Own,
                         name: m.name.clone(),
@@ -711,6 +719,7 @@ impl Resolver {
 
     fn lower_type_alias(&mut self, t: &ir::NewType, tags: &Tags) -> NewType {
         NewType {
+            comments: t.comments.clone(),
             name: t.name.clone(),
             ty: {
                 let ty = self.lower_type(&t.ty, false);
@@ -737,6 +746,7 @@ impl Resolver {
 
     fn lower_const(&mut self, c: &ir::Const, tags: &Tags) -> Const {
         Const {
+            comments: c.comments.clone(),
             name: c.name.clone(),
             ty: {
                 let ty = self.lower_type(&c.ty, false);

--- a/pilota-build/test_data/thrift/apache.rs
+++ b/pilota-build/test_data/thrift/apache.rs
@@ -7,6 +7,9 @@ pub mod apache {
 
             pub mod test {
 
+                /**
+                 * Docstring!
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
                 #[repr(transparent)]
                 pub struct Numberz(i32);
@@ -570,6 +573,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI32ArgsSend {
                     pub thing: i32,
@@ -735,6 +743,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param set<i32> thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestSetArgsRecv {
                     pub thing: ::pilota::AHashSet<i32>,
@@ -927,6 +941,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                 * @param string arg - a string indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                 * else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiExceptionException {
                     fn default() -> Self {
                         ThriftTestTestMultiExceptionException::Err1(
@@ -1129,6 +1152,9 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestVoidArgsSend {}
                 impl ::pilota::thrift::Message for ThriftTestTestVoidArgsSend {
@@ -1260,6 +1286,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStructArgsRecv {
                     pub thing: Xtruct,
@@ -1430,6 +1461,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMultiResultRecv::Ok(::std::default::Default::default())
@@ -1437,6 +1480,17 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiResultRecv {
+                    /**
+                     * Prints 'testMulti()'
+                     * @param i8 arg0 -
+                     * @param i32 arg1 -
+                     * @param i64 arg2 -
+                     * @param map<i16, string> arg3 -
+                     * @param Numberz arg4 -
+                     * @param UserId arg5 -
+                     * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                     *    and i64_thing = arg2
+                     */
                     Ok(Xtruct),
                 }
 
@@ -1767,6 +1821,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI64ArgsRecv {
                     pub thing: i64,
@@ -1932,6 +1991,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                 * @param Numberz thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestEnumResultRecv {
                     fn default() -> Self {
                         ThriftTestTestEnumResultRecv::Ok(::std::default::Default::default())
@@ -1939,6 +2004,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestEnumResultRecv {
+                    /**
+                     * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                     * @param Numberz thing - the Numberz to print
+                     * @return Numberz - returns the Numberz 'thing'
+                     */
                     Ok(Numberz),
                 }
 
@@ -2082,6 +2152,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                 * sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                 * @param i32 secondsToSleep - the number of seconds to sleep
+                 */
+
                 impl ::std::default::Default for ThriftTestTestOnewayResultSend {
                     fn default() -> Self {
                         ThriftTestTestOnewayResultSend::Ok(::std::default::Default::default())
@@ -2089,6 +2166,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestOnewayResultSend {
+                    /**
+                     * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                     * sleep 'secondsToSleep'
+                     * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                     * @param i32 secondsToSleep - the number of seconds to sleep
+                     */
                     Ok(()),
                 }
 
@@ -2194,6 +2277,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringArgsRecv {
                     pub thing: ::pilota::FastStr,
@@ -2359,6 +2447,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMapResultRecv::Ok(::std::default::Default::default())
@@ -2366,6 +2461,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapResultRecv {
+                    /**
+                     * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<i32,i32> thing - the map<i32,i32> to print
+                     * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                     */
                     Ok(::pilota::AHashMap<i32, i32>),
                 }
 
@@ -2780,6 +2881,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                 * @param binary  thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBinaryResultRecv {
                     fn default() -> Self {
                         ThriftTestTestBinaryResultRecv::Ok(::std::default::Default::default())
@@ -2787,6 +2894,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBinaryResultRecv {
+                    /**
+                     * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                     * @param binary  thing - the binary data to print
+                     * @return binary  - returns the binary 'thing'
+                     */
                     Ok(::pilota::Bytes),
                 }
 
@@ -2930,6 +3042,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for SecondServiceSecondtestStringResultSend {
                     fn default() -> Self {
                         SecondServiceSecondtestStringResultSend::Ok(
@@ -2939,6 +3057,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum SecondServiceSecondtestStringResultSend {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -3085,6 +3208,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                 * @param byte thing - the i8/byte to print
+                 * @return i8 - returns the i8/byte 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestByteResultRecv {
                     fn default() -> Self {
                         ThriftTestTestByteResultRecv::Ok(::std::default::Default::default())
@@ -3092,6 +3222,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestByteResultRecv {
+                    /**
+                     * Prints 'testByte("%d")' with thing as '%d'
+                     * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                     * @param byte thing - the i8/byte to print
+                     * @return i8 - returns the i8/byte 'thing'
+                     */
                     Ok(i8),
                 }
 
@@ -3234,6 +3370,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of exception to throw
+                 * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestExceptionArgsSend {
                     pub arg: ::pilota::FastStr,
@@ -3399,6 +3542,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                 *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapMapResultSend {
                     fn default() -> Self {
                         ThriftTestTestMapMapResultSend::Ok(::std::default::Default::default())
@@ -3406,6 +3556,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapMapResultSend {
+                    /**
+                     * Prints 'testMapMap("%d")' with hello as '%d'
+                     * @param i32 hello - the i32 to print
+                     * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                     *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                     */
                     Ok(::pilota::AHashMap<i32, ::pilota::AHashMap<i32, i32>>),
                 }
 
@@ -3857,6 +4013,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param set<i32> thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestSetResultSend {
                     fn default() -> Self {
                         ThriftTestTestSetResultSend::Ok(::std::default::Default::default())
@@ -3864,6 +4027,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestSetResultSend {
+                    /**
+                     * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param set<i32> thing - the set<i32> to print
+                     * @return set<i32> - returns the set<i32> 'thing'
+                     */
                     Ok(::pilota::AHashSet<i32>),
                 }
 
@@ -4041,6 +4210,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStructResultSend {
                     fn default() -> Self {
                         ThriftTestTestStructResultSend::Ok(::std::default::Default::default())
@@ -4048,6 +4223,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStructResultSend {
+                    /**
+                     * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                     * @param Xtruct thing - the Xtruct to print
+                     * @return Xtruct - returns the Xtruct 'thing'
+                     */
                     Ok(Xtruct),
                 }
 
@@ -4632,6 +4812,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI64ResultSend {
                     fn default() -> Self {
                         ThriftTestTestI64ResultSend::Ok(::std::default::Default::default())
@@ -4639,6 +4825,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI64ResultSend {
+                    /**
+                     * Prints 'testI64("%d")' with thing as '%d'
+                     * @param i64 thing - the i64 to print
+                     * @return i64 - returns the i64 'thing'
+                     */
                     Ok(i64),
                 }
 
@@ -4781,6 +4972,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                 * @param string arg - a string indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                 * else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiExceptionArgsRecv {
                     pub arg0: ::pilota::FastStr,
@@ -4983,6 +5182,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringResultSend {
                     fn default() -> Self {
                         ThriftTestTestStringResultSend::Ok(::std::default::Default::default())
@@ -4990,6 +5195,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringResultSend {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -5133,6 +5343,17 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiArgsSend {
                     pub arg0: i8,
@@ -5705,6 +5926,7 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub struct OptionalBinary {
+                    //1: optional set<binary> bin_set = []
                     pub bin_map: ::std::option::Option<::pilota::AHashMap<::pilota::Bytes, i32>>,
                 }
                 impl ::pilota::thrift::Message for OptionalBinary {
@@ -5912,6 +6134,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                 * @param Numberz thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestEnumArgsSend {
                     pub thing: Numberz,
@@ -6079,6 +6306,13 @@ pub mod apache {
                     }
                 }
                 pub trait ThriftTest {}
+
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapArgsSend {
                     pub thing: ::pilota::AHashMap<i32, i32>,
@@ -6283,6 +6517,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                 * @param binary  thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBinaryArgsSend {
                     pub thing: ::pilota::Bytes,
@@ -6448,6 +6687,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestTypedefArgsRecv {
                     pub thing: UserId,
@@ -6619,6 +6863,13 @@ pub mod apache {
                     }
                 }
                 pub trait SecondService {}
+
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                 * @param byte thing - the i8/byte to print
+                 * @return i8 - returns the i8/byte 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestByteArgsSend {
                     pub thing: i8,
@@ -6784,6 +7035,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string> to print
+                 * @return map<string,string> - returns the map<string,string> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringMapArgsRecv {
                     pub thing: ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
@@ -7122,6 +7379,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestUuidArgsRecv {
                     pub thing: [u8; 16],
@@ -7287,6 +7549,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                 */
+
                 impl ::std::default::Default for ThriftTestTestInsanityResultRecv {
                     fn default() -> Self {
                         ThriftTestTestInsanityResultRecv::Ok(::std::default::Default::default())
@@ -7294,6 +7568,17 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestInsanityResultRecv {
+                    /**
+                     * So you think you've got this all worked out, eh?
+                     *
+                     * Creates a map with these values and prints it out:
+                     *   { 1 => { 2 => argument,
+                     *            3 => argument,
+                     *          },
+                     *     2 => { 6 => <empty Insanity struct>, },
+                     *   }
+                     * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                     */
                     Ok(::pilota::AHashMap<UserId, ::pilota::AHashMap<Numberz, Insanity>>),
                 }
 
@@ -7757,6 +8042,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI32ArgsRecv {
                     pub thing: i32,
@@ -7922,6 +8212,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param list<i32> thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestListResultRecv {
                     fn default() -> Self {
                         ThriftTestTestListResultRecv::Ok(::std::default::Default::default())
@@ -7929,6 +8226,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestListResultRecv {
+                    /**
+                     * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param list<i32> thing - the list<i32> to print
+                     * @return list<i32> - returns the list<i32> 'thing'
+                     */
                     Ok(::std::vec::Vec<i32>),
                 }
 
@@ -8108,6 +8411,9 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestVoidArgsRecv {}
                 impl ::pilota::thrift::Message for ThriftTestTestVoidArgsRecv {
@@ -8239,6 +8545,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                 * @param Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestNestResultRecv {
                     fn default() -> Self {
                         ThriftTestTestNestResultRecv::Ok(::std::default::Default::default())
@@ -8246,6 +8558,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestNestResultRecv {
+                    /**
+                     * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                     * @param Xtruct2 thing - the Xtruct2 to print
+                     * @return Xtruct2 - returns the Xtruct2 'thing'
+                     */
                     Ok(Xtruct2),
                 }
 
@@ -8393,6 +8710,9 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                // the following is expected to fail:
+
+                // const Numberz urNumberz = ONE;
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct UserId(pub i64);
 
@@ -8624,6 +8944,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestDoubleResultRecv {
                     fn default() -> Self {
                         ThriftTestTestDoubleResultRecv::Ok(::std::default::Default::default())
@@ -8631,6 +8957,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestDoubleResultRecv {
+                    /**
+                     * Prints 'testDouble("%f")' with thing as '%f'
+                     * @param double thing - the double to print
+                     * @return double - returns the double 'thing'
+                     */
                     Ok(f64),
                 }
 
@@ -8774,6 +9105,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                 * @param bool  thing - the bool data to print
+                 * @return bool  - returns the bool 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBoolResultRecv {
                     fn default() -> Self {
                         ThriftTestTestBoolResultRecv::Ok(::std::default::Default::default())
@@ -8781,6 +9118,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBoolResultRecv {
+                    /**
+                     * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                     * @param bool  thing - the bool data to print
+                     * @return bool  - returns the bool 'thing'
+                     */
                     Ok(bool),
                 }
 
@@ -9171,6 +9513,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestTypedefResultSend {
                     fn default() -> Self {
                         ThriftTestTestTypedefResultSend::Ok(::std::default::Default::default())
@@ -9178,6 +9526,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestTypedefResultSend {
+                    /**
+                     * Prints 'testTypedef("%d")' with thing as '%d'
+                     * @param UserId thing - the UserId to print
+                     * @return UserId - returns the UserId 'thing'
+                     */
                     Ok(UserId),
                 }
 
@@ -9327,6 +9680,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string> to print
+                 * @return map<string,string> - returns the map<string,string> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringMapResultSend {
                     fn default() -> Self {
                         ThriftTestTestStringMapResultSend::Ok(::std::default::Default::default())
@@ -9334,6 +9694,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringMapResultSend {
+                    /**
+                     * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<string,string> thing - the map<string,string> to print
+                     * @return map<string,string> - returns the map<string,string> 'thing'
+                     */
                     Ok(::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>),
                 }
 
@@ -9529,6 +9895,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of exception to throw
+                 * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestExceptionArgsRecv {
                     pub arg: ::pilota::FastStr,
@@ -9694,6 +10067,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestUuidResultSend {
                     fn default() -> Self {
                         ThriftTestTestUuidResultSend::Ok(::std::default::Default::default())
@@ -9701,6 +10080,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestUuidResultSend {
+                    /**
+                     * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                     * @param uuid  thing - the uuid to print
+                     * @return uuid  - returns the uuid 'thing'
+                     */
                     Ok([u8; 16]),
                 }
 
@@ -10052,6 +10436,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI32ResultSend {
                     fn default() -> Self {
                         ThriftTestTestI32ResultSend::Ok(::std::default::Default::default())
@@ -10059,6 +10449,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI32ResultSend {
+                    /**
+                     * Prints 'testI32("%d")' with thing as '%d'
+                     * @param i32 thing - the i32 to print
+                     * @return i32 - returns the i32 'thing'
+                     */
                     Ok(i32),
                 }
 
@@ -10201,6 +10596,10 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
+
                 impl ::std::default::Default for ThriftTestTestVoidResultSend {
                     fn default() -> Self {
                         ThriftTestTestVoidResultSend::Ok(::std::default::Default::default())
@@ -10208,6 +10607,9 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestVoidResultSend {
+                    /**
+                     * Prints "testVoid()" and returns nothing.
+                     */
                     Ok(()),
                 }
 
@@ -10313,6 +10715,17 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestInsanityArgsSend {
                     pub argument: Insanity,
@@ -10668,6 +11081,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param list<i32> thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestListArgsSend {
                     pub thing: ::std::vec::Vec<i32>,
@@ -10865,6 +11284,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                 * sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                 * @param i32 secondsToSleep - the number of seconds to sleep
+                 */
+
                 impl ::std::default::Default for ThriftTestTestOnewayResultRecv {
                     fn default() -> Self {
                         ThriftTestTestOnewayResultRecv::Ok(::std::default::Default::default())
@@ -10872,6 +11298,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestOnewayResultRecv {
+                    /**
+                     * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                     * sleep 'secondsToSleep'
+                     * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                     * @param i32 secondsToSleep - the number of seconds to sleep
+                     */
                     Ok(()),
                 }
 
@@ -10977,6 +11409,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                 * @param Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestNestArgsSend {
                     pub thing: Xtruct2,
@@ -11147,6 +11584,17 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiArgsRecv {
                     pub arg0: i8,
@@ -11750,6 +12198,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
                 #[derive(PartialOrd, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestDoubleArgsSend {
                     pub thing: f64,
@@ -11915,6 +12368,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                 * @param Numberz thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestEnumArgsRecv {
                     pub thing: Numberz,
@@ -12081,6 +12539,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for SecondServiceSecondtestStringResultRecv {
                     fn default() -> Self {
                         SecondServiceSecondtestStringResultRecv::Ok(
@@ -12090,6 +12554,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum SecondServiceSecondtestStringResultRecv {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -12236,6 +12705,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                 * @param bool  thing - the bool data to print
+                 * @return bool  - returns the bool 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBoolArgsSend {
                     pub thing: bool,
@@ -12401,6 +12875,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapArgsRecv {
                     pub thing: ::pilota::AHashMap<i32, i32>,
@@ -12605,6 +13085,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of exception to throw
+                 * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
+
                 impl ::std::default::Default for ThriftTestTestExceptionException {
                     fn default() -> Self {
                         ThriftTestTestExceptionException::Err1(::std::default::Default::default())
@@ -12762,6 +13250,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                 * @param binary  thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBinaryArgsRecv {
                     pub thing: ::pilota::Bytes,
@@ -12927,6 +13420,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                 *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapMapResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMapMapResultRecv::Ok(::std::default::Default::default())
@@ -12934,6 +13434,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapMapResultRecv {
+                    /**
+                     * Prints 'testMapMap("%d")' with hello as '%d'
+                     * @param i32 hello - the i32 to print
+                     * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                     *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                     */
                     Ok(::pilota::AHashMap<i32, ::pilota::AHashMap<i32, i32>>),
                 }
 
@@ -13376,6 +13882,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                 * @param byte thing - the i8/byte to print
+                 * @return i8 - returns the i8/byte 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestByteArgsRecv {
                     pub thing: i8,
@@ -13541,6 +14053,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param set<i32> thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestSetResultRecv {
                     fn default() -> Self {
                         ThriftTestTestSetResultRecv::Ok(::std::default::Default::default())
@@ -13548,6 +14067,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestSetResultRecv {
+                    /**
+                     * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param set<i32> thing - the set<i32> to print
+                     * @return set<i32> - returns the set<i32> 'thing'
+                     */
                     Ok(::pilota::AHashSet<i32>),
                 }
 
@@ -13883,6 +14408,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStructResultRecv {
                     fn default() -> Self {
                         ThriftTestTestStructResultRecv::Ok(::std::default::Default::default())
@@ -13890,6 +14421,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStructResultRecv {
+                    /**
+                     * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                     * @param Xtruct thing - the Xtruct to print
+                     * @return Xtruct - returns the Xtruct 'thing'
+                     */
                     Ok(Xtruct),
                 }
 
@@ -14298,6 +14834,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI64ResultRecv {
                     fn default() -> Self {
                         ThriftTestTestI64ResultRecv::Ok(::std::default::Default::default())
@@ -14305,6 +14847,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI64ResultRecv {
+                    /**
+                     * Prints 'testI64("%d")' with thing as '%d'
+                     * @param i64 thing - the i64 to print
+                     * @return i64 - returns the i64 'thing'
+                     */
                     Ok(i64),
                 }
 
@@ -14447,6 +14994,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringResultRecv {
                     fn default() -> Self {
                         ThriftTestTestStringResultRecv::Ok(::std::default::Default::default())
@@ -14454,6 +15007,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringResultRecv {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -14597,6 +15155,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiResultSend {
                     fn default() -> Self {
                         ThriftTestTestMultiResultSend::Ok(::std::default::Default::default())
@@ -14604,6 +15174,17 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiResultSend {
+                    /**
+                     * Prints 'testMulti()'
+                     * @param i8 arg0 -
+                     * @param i32 arg1 -
+                     * @param i64 arg2 -
+                     * @param map<i16, string> arg3 -
+                     * @param Numberz arg4 -
+                     * @param UserId arg5 -
+                     * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                     *    and i64_thing = arg2
+                     */
                     Ok(Xtruct),
                 }
 
@@ -15133,6 +15714,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                 * @param Numberz thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestEnumResultSend {
                     fn default() -> Self {
                         ThriftTestTestEnumResultSend::Ok(::std::default::Default::default())
@@ -15140,6 +15727,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestEnumResultSend {
+                    /**
+                     * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                     * @param Numberz thing - the Numberz to print
+                     * @return Numberz - returns the Numberz 'thing'
+                     */
                     Ok(Numberz),
                 }
 
@@ -15283,6 +15875,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                 * sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                 * @param i32 secondsToSleep - the number of seconds to sleep
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestOnewayArgsSend {
                     pub seconds_to_sleep: i32,
@@ -15452,6 +16050,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapResultSend {
                     fn default() -> Self {
                         ThriftTestTestMapResultSend::Ok(::std::default::Default::default())
@@ -15459,6 +16064,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapResultSend {
+                    /**
+                     * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<i32,i32> thing - the map<i32,i32> to print
+                     * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                     */
                     Ok(::pilota::AHashMap<i32, i32>),
                 }
 
@@ -15650,6 +16261,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of exception to throw
+                 * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
+
                 impl ::std::default::Default for ThriftTestTestExceptionResultSend {
                     fn default() -> Self {
                         ThriftTestTestExceptionResultSend::Ok(::std::default::Default::default())
@@ -15657,6 +16276,13 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestExceptionResultSend {
+                    /**
+                     * Print 'testException(%s)' with arg as '%s'
+                     * @param string arg - a string indication what type of exception to throw
+                     * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                     * else if arg == "TException" throw TException
+                     * else do not throw anything
+                     */
                     Ok(()),
 
                     Err1(Xception),
@@ -15809,6 +16435,7 @@ pub mod apache {
 
                     pub set_field: ::std::option::Option<::pilota::AHashSet<Insanity>>,
 
+                    // Do not insert line break as test/go/Makefile.am is removing this line with pattern match
                     pub list_field: ::std::vec::Vec<
                         ::std::collections::BTreeMap<
                             ::std::collections::BTreeSet<i32>,
@@ -16255,6 +16882,12 @@ pub mod apache {
                     }) +self.binary_field.as_ref().map_or(0, |value| __protocol.bytes_field_len(Some(4), value)) +self.uuid_field.as_ref().map_or(0, |value| __protocol.uuid_field_len(Some(5), *value) ) + __protocol.field_stop_len() + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                 * @param binary  thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBinaryResultSend {
                     fn default() -> Self {
                         ThriftTestTestBinaryResultSend::Ok(::std::default::Default::default())
@@ -16262,6 +16895,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBinaryResultSend {
+                    /**
+                     * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                     * @param binary  thing - the binary data to print
+                     * @return binary  - returns the binary 'thing'
+                     */
                     Ok(::pilota::Bytes),
                 }
 
@@ -16405,6 +17043,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct SecondServiceSecondtestStringArgsSend {
                     pub thing: ::pilota::FastStr,
@@ -16570,6 +17213,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                 * @param byte thing - the i8/byte to print
+                 * @return i8 - returns the i8/byte 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestByteResultSend {
                     fn default() -> Self {
                         ThriftTestTestByteResultSend::Ok(::std::default::Default::default())
@@ -16577,6 +17227,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestByteResultSend {
+                    /**
+                     * Prints 'testByte("%d")' with thing as '%d'
+                     * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                     * @param byte thing - the i8/byte to print
+                     * @return i8 - returns the i8/byte 'thing'
+                     */
                     Ok(i8),
                 }
 
@@ -16719,6 +17375,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                 * @param string arg - a string indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                 * else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiExceptionResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMultiExceptionResultRecv::Ok(
@@ -16728,6 +17393,14 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiExceptionResultRecv {
+                    /**
+                     * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                     * @param string arg - a string indicating what type of exception to throw
+                     * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                     * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                     * else do not throw anything
+                     * @return Xtruct - an Xtruct with string_thing = arg1
+                     */
                     Ok(Xtruct),
 
                     Err1(Xception),
@@ -17141,6 +17814,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                 *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapMapArgsSend {
                     pub hello: i32,
@@ -17498,6 +18177,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param set<i32> thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestSetArgsSend {
                     pub thing: ::pilota::AHashSet<i32>,
@@ -17690,6 +18375,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStructArgsSend {
                     pub thing: Xtruct,
@@ -17860,6 +18550,17 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestInsanityArgsRecv {
                     pub argument: Insanity,
@@ -18274,6 +18975,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI64ArgsSend {
                     pub thing: i64,
@@ -18439,6 +19145,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param list<i32> thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestListArgsRecv {
                     pub thing: ::std::vec::Vec<i32>,
@@ -18636,6 +19348,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringArgsSend {
                     pub thing: ::pilota::FastStr,
@@ -18801,6 +19518,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                 * @param Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestNestArgsRecv {
                     pub thing: Xtruct2,
@@ -18971,6 +19693,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of exception to throw
+                 * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
+
                 impl ::std::default::Default for ThriftTestTestExceptionResultRecv {
                     fn default() -> Self {
                         ThriftTestTestExceptionResultRecv::Ok(::std::default::Default::default())
@@ -18978,6 +19708,13 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestExceptionResultRecv {
+                    /**
+                     * Print 'testException(%s)' with arg as '%s'
+                     * @param string arg - a string indication what type of exception to throw
+                     * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                     * else if arg == "TException" throw TException
+                     * else do not throw anything
+                     */
                     Ok(()),
 
                     Err1(Xception),
@@ -19128,6 +19865,7 @@ pub mod apache {
                 pub struct Xtruct2 {
                     pub byte_thing: ::std::option::Option<i8>,
 
+                    // used to be byte, hence the name
                     pub struct_thing: ::std::option::Option<Xtruct>,
 
                     pub i32_thing: ::std::option::Option<i32>,
@@ -19330,6 +20068,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
                 #[derive(PartialOrd, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestDoubleArgsRecv {
                     pub thing: f64,
@@ -19495,6 +20238,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestTypedefResultRecv {
                     fn default() -> Self {
                         ThriftTestTestTypedefResultRecv::Ok(::std::default::Default::default())
@@ -19502,6 +20251,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestTypedefResultRecv {
+                    /**
+                     * Prints 'testTypedef("%d")' with thing as '%d'
+                     * @param UserId thing - the UserId to print
+                     * @return UserId - returns the UserId 'thing'
+                     */
                     Ok(UserId),
                 }
 
@@ -19651,6 +20405,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                 * @param bool  thing - the bool data to print
+                 * @return bool  - returns the bool 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBoolArgsRecv {
                     pub thing: bool,
@@ -19816,6 +20575,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string> to print
+                 * @return map<string,string> - returns the map<string,string> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringMapResultRecv {
                     fn default() -> Self {
                         ThriftTestTestStringMapResultRecv::Ok(::std::default::Default::default())
@@ -19823,6 +20589,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringMapResultRecv {
+                    /**
+                     * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<string,string> thing - the map<string,string> to print
+                     * @return map<string,string> - returns the map<string,string> 'thing'
+                     */
                     Ok(::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>),
                 }
 
@@ -20018,6 +20790,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestUuidResultRecv {
                     fn default() -> Self {
                         ThriftTestTestUuidResultRecv::Ok(::std::default::Default::default())
@@ -20025,6 +20803,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestUuidResultRecv {
+                    /**
+                     * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                     * @param uuid  thing - the uuid to print
+                     * @return uuid  - returns the uuid 'thing'
+                     */
                     Ok([u8; 16]),
                 }
 
@@ -20668,6 +21451,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI32ResultRecv {
                     fn default() -> Self {
                         ThriftTestTestI32ResultRecv::Ok(::std::default::Default::default())
@@ -20675,6 +21464,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI32ResultRecv {
+                    /**
+                     * Prints 'testI32("%d")' with thing as '%d'
+                     * @param i32 thing - the i32 to print
+                     * @return i32 - returns the i32 'thing'
+                     */
                     Ok(i32),
                 }
 
@@ -20817,6 +21611,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                 * @param string arg - a string indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                 * else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiExceptionResultSend {
                     fn default() -> Self {
                         ThriftTestTestMultiExceptionResultSend::Ok(
@@ -20826,6 +21629,14 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiExceptionResultSend {
+                    /**
+                     * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                     * @param string arg - a string indicating what type of exception to throw
+                     * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                     * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                     * else do not throw anything
+                     * @return Xtruct - an Xtruct with string_thing = arg1
+                     */
                     Ok(Xtruct),
 
                     Err1(Xception),
@@ -21060,6 +21871,10 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
+
                 impl ::std::default::Default for ThriftTestTestVoidResultRecv {
                     fn default() -> Self {
                         ThriftTestTestVoidResultRecv::Ok(::std::default::Default::default())
@@ -21067,6 +21882,9 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestVoidResultRecv {
+                    /**
+                     * Prints "testVoid()" and returns nothing.
+                     */
                     Ok(()),
                 }
 
@@ -21172,6 +21990,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                 */
+
                 impl ::std::default::Default for ThriftTestTestInsanityResultSend {
                     fn default() -> Self {
                         ThriftTestTestInsanityResultSend::Ok(::std::default::Default::default())
@@ -21179,6 +22009,17 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestInsanityResultSend {
+                    /**
+                     * So you think you've got this all worked out, eh?
+                     *
+                     * Creates a map with these values and prints it out:
+                     *   { 1 => { 2 => argument,
+                     *            3 => argument,
+                     *          },
+                     *     2 => { 6 => <empty Insanity struct>, },
+                     *   }
+                     * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                     */
                     Ok(::pilota::AHashMap<UserId, ::pilota::AHashMap<Numberz, Insanity>>),
                 }
 
@@ -21642,6 +22483,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param list<i32> thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestListResultSend {
                     fn default() -> Self {
                         ThriftTestTestListResultSend::Ok(::std::default::Default::default())
@@ -21649,6 +22497,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestListResultSend {
+                    /**
+                     * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param list<i32> thing - the list<i32> to print
+                     * @return list<i32> - returns the list<i32> 'thing'
+                     */
                     Ok(::std::vec::Vec<i32>),
                 }
 
@@ -21828,6 +22682,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                 * @param string arg - a string indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                 * else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiExceptionArgsSend {
                     pub arg0: ::pilota::FastStr,
@@ -22030,6 +22892,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                 * @param Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestNestResultSend {
                     fn default() -> Self {
                         ThriftTestTestNestResultSend::Ok(::std::default::Default::default())
@@ -22037,6 +22905,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestNestResultSend {
+                    /**
+                     * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                     * @param Xtruct2 thing - the Xtruct2 to print
+                     * @return Xtruct2 - returns the Xtruct2 'thing'
+                     */
                     Ok(Xtruct2),
                 }
 
@@ -22495,6 +23368,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestDoubleResultSend {
                     fn default() -> Self {
                         ThriftTestTestDoubleResultSend::Ok(::std::default::Default::default())
@@ -22502,6 +23381,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestDoubleResultSend {
+                    /**
+                     * Prints 'testDouble("%f")' with thing as '%f'
+                     * @param double thing - the double to print
+                     * @return double - returns the double 'thing'
+                     */
                     Ok(f64),
                 }
 
@@ -22645,6 +23529,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                 * sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                 * @param i32 secondsToSleep - the number of seconds to sleep
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestOnewayArgsRecv {
                     pub seconds_to_sleep: i32,
@@ -22814,6 +23704,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                 * @param bool  thing - the bool data to print
+                 * @return bool  - returns the bool 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBoolResultSend {
                     fn default() -> Self {
                         ThriftTestTestBoolResultSend::Ok(::std::default::Default::default())
@@ -22821,6 +23717,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBoolResultSend {
+                    /**
+                     * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                     * @param bool  thing - the bool data to print
+                     * @return bool  - returns the bool 'thing'
+                     */
                     Ok(bool),
                 }
 
@@ -23293,6 +24194,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestTypedefArgsSend {
                     pub thing: UserId,
@@ -23463,6 +24369,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct SecondServiceSecondtestStringArgsRecv {
                     pub thing: ::pilota::FastStr,
@@ -23628,6 +24539,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string> to print
+                 * @return map<string,string> - returns the map<string,string> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringMapArgsSend {
                     pub thing: ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
@@ -24017,6 +24934,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestUuidArgsSend {
                     pub thing: [u8; 16],
@@ -24182,6 +25104,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                 *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapMapArgsRecv {
                     pub hello: i32,

--- a/pilota-build/test_data/thrift/comments.rs
+++ b/pilota-build/test_data/thrift/comments.rs
@@ -1,0 +1,1465 @@
+pub mod comments {
+    #![allow(warnings, clippy::all)]
+
+    pub mod volo {
+
+        pub mod rpc {
+
+            pub mod example {
+
+                /*
+                 * Item struct represents an item with id, title, content, and extra metadata
+                 */
+
+                // This is a comment for the Item struct
+                #[derive(Debug, Default, Clone, PartialEq)]
+                pub struct Item {
+                    // id of the item
+                    pub id: i64,
+
+                    // title of the item
+
+                    /*
+                     * title of the item
+                     */
+                    pub title: ::pilota::FastStr,
+
+                    // content of the item
+                    pub content: ::pilota::FastStr,
+
+                    // extra metadata of the item
+                    pub extra: ::std::option::Option<
+                        ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
+                    >,
+                }
+                impl ::pilota::thrift::Message for Item {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Item" };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_i64_field(1, *&self.id)?;
+                        __protocol.write_faststr_field(2, (&self.title).clone())?;
+                        __protocol.write_faststr_field(3, (&self.content).clone())?;
+                        if let Some(value) = self.extra.as_ref() {
+                            __protocol.write_map_field(
+                                10,
+                                ::pilota::thrift::TType::Binary,
+                                ::pilota::thrift::TType::Binary,
+                                &value,
+                                |__protocol, key| {
+                                    __protocol.write_faststr((key).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_faststr((val).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+                        let mut var_2 = None;
+                        let mut var_3 = None;
+                        let mut var_10 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::I64 =>
+                                    {
+                                        var_1 = Some(__protocol.read_i64()?);
+                                    }
+                                    Some(2)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Binary =>
+                                    {
+                                        var_2 = Some(__protocol.read_faststr()?);
+                                    }
+                                    Some(3)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Binary =>
+                                    {
+                                        var_3 = Some(__protocol.read_faststr()?);
+                                    }
+                                    Some(10)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Map =>
+                                    {
+                                        var_10 = Some({
+                                            let map_ident = __protocol.read_map_begin()?;
+                                            let mut val =
+                                                ::pilota::AHashMap::with_capacity(map_ident.size);
+                                            for _ in 0..map_ident.size {
+                                                val.insert(
+                                                    __protocol.read_faststr()?,
+                                                    __protocol.read_faststr()?,
+                                                );
+                                            }
+                                            __protocol.read_map_end()?;
+                                            val
+                                        });
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!(
+                                    "decode struct `Item` field(#{}) failed, caused by: ",
+                                    field_id
+                                ));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field id is required".to_string(),
+                                ),
+                            );
+                        };
+                        let Some(var_2) = var_2 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field title is required".to_string(),
+                                ),
+                            );
+                        };
+                        let Some(var_3) = var_3 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field content is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self {
+                            id: var_1,
+                            title: var_2,
+                            content: var_3,
+                            extra: var_10,
+                        };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+                            let mut var_2 = None;
+                            let mut var_3 = None;
+                            let mut var_10 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64  => {
+                    var_1 = Some(__protocol.read_i64().await?);
+
+                },Some(2) if field_ident.field_type == ::pilota::thrift::TType::Binary  => {
+                    var_2 = Some(__protocol.read_faststr().await?);
+
+                },Some(3) if field_ident.field_type == ::pilota::thrift::TType::Binary  => {
+                    var_3 = Some(__protocol.read_faststr().await?);
+
+                },Some(10) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_10 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(__protocol.read_faststr().await?, __protocol.read_faststr().await?);
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `Item` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field id is required".to_string(),
+                                    ),
+                                );
+                            };
+                            let Some(var_2) = var_2 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field title is required".to_string(),
+                                    ),
+                                );
+                            };
+                            let Some(var_3) = var_3 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field content is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self {
+                                id: var_1,
+                                title: var_2,
+                                content: var_3,
+                                extra: var_10,
+                            };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol
+                            .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
+                            + __protocol.i64_field_len(Some(1), *&self.id)
+                            + __protocol.faststr_field_len(Some(2), &self.title)
+                            + __protocol.faststr_field_len(Some(3), &self.content)
+                            + self.extra.as_ref().map_or(0, |value| {
+                                __protocol.map_field_len(
+                                    Some(10),
+                                    ::pilota::thrift::TType::Binary,
+                                    ::pilota::thrift::TType::Binary,
+                                    value,
+                                    |__protocol, key| __protocol.faststr_len(key),
+                                    |__protocol, val| __protocol.faststr_len(val),
+                                )
+                            })
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // method to get an item
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+                pub struct TestServiceGetItemArgsRecv {
+                    pub req: GetItemRequest,
+                }
+                impl ::pilota::thrift::Message for TestServiceGetItemArgsRecv {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsRecv",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_struct_field(
+                            1,
+                            &self.req,
+                            ::pilota::thrift::TType::Struct,
+                        )?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Struct =>
+                                    {
+                                        var_1 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsRecv` field(#{}) failed, caused by: ", field_id));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field req is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { req: var_1 };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<GetItemRequest as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsRecv` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field req is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self { req: var_1 };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsRecv",
+                        }) + __protocol.struct_field_len(Some(1), &self.req)
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // method to get an item
+
+                impl ::std::default::Default for TestServiceGetItemResultSend {
+                    fn default() -> Self {
+                        TestServiceGetItemResultSend::Ok(::std::default::Default::default())
+                    }
+                }
+                #[derive(Debug, Clone, PartialEq)]
+                pub enum TestServiceGetItemResultSend {
+                    // method to get an item
+                    Ok(GetItemResponse),
+                }
+
+                impl ::pilota::thrift::Message for TestServiceGetItemResultSend {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultSend",
+                        })?;
+                        match self {
+                            TestServiceGetItemResultSend::Ok(value) => {
+                                __protocol.write_struct_field(
+                                    0,
+                                    value,
+                                    ::pilota::thrift::TType::Struct,
+                                )?;
+                            }
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                        let mut ret = None;
+                        __protocol.read_struct_begin()?;
+                        loop {
+                            let field_ident = __protocol.read_field_begin()?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                __protocol.field_stop_len();
+                                break;
+                            } else {
+                                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                            }
+                            match field_ident.id {
+                                Some(0) => {
+                                    if ret.is_none() {
+                                        let field_ident =
+                                            ::pilota::thrift::Message::decode(__protocol)?;
+                                        __protocol.struct_len(&field_ident);
+                                        ret = Some(TestServiceGetItemResultSend::Ok(field_ident));
+                                    } else {
+                                        return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                    }
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type)?;
+                                }
+                            }
+                        }
+                        __protocol.read_field_end()?;
+                        __protocol.read_struct_end()?;
+                        if let Some(ret) = ret {
+                            ::std::result::Result::Ok(ret)
+                        } else {
+                            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received empty union from remote Message",
+                            ))
+                        }
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut ret = None;
+                            __protocol.read_struct_begin().await?;
+                            loop {
+                                let field_ident = __protocol.read_field_begin().await?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    break;
+                                } else {
+                                }
+                                match field_ident.id {
+                                    Some(0) => {
+                                        if ret.is_none() {
+                                            let field_ident = <GetItemResponse as ::pilota::thrift::Message>::decode_async(__protocol).await?;
+
+                                            ret =
+                                                Some(TestServiceGetItemResultSend::Ok(field_ident));
+                                        } else {
+                                            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                        }
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type).await?;
+                                    }
+                                }
+                            }
+                            __protocol.read_field_end().await?;
+                            __protocol.read_struct_end().await?;
+                            if let Some(ret) = ret {
+                                ::std::result::Result::Ok(ret)
+                            } else {
+                                ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received empty union from remote Message",
+                                    ),
+                                )
+                            }
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultSend",
+                        }) + match self {
+                            TestServiceGetItemResultSend::Ok(value) => {
+                                __protocol.struct_field_len(Some(0), value)
+                            }
+                        } + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                #[derive(Debug, Default, Clone, PartialEq)]
+                pub struct GetItemResponse {
+                    pub item: Item,
+
+                    pub status: Status,
+                }
+                impl ::pilota::thrift::Message for GetItemResponse {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "GetItemResponse",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_struct_field(
+                            1,
+                            &self.item,
+                            ::pilota::thrift::TType::Struct,
+                        )?;
+                        __protocol.write_i32_field(2, (&self.status).inner())?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+                        let mut var_2 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Struct =>
+                                    {
+                                        var_1 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    Some(2)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::I32 =>
+                                    {
+                                        var_2 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!("decode struct `GetItemResponse` field(#{}) failed, caused by: ", field_id));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field item is required".to_string(),
+                                ),
+                            );
+                        };
+                        let Some(var_2) = var_2 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field status is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self {
+                            item: var_1,
+                            status: var_2,
+                        };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+                            let mut var_2 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<Item as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },Some(2) if field_ident.field_type == ::pilota::thrift::TType::I32  => {
+                    var_2 = Some(<Status as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `GetItemResponse` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field item is required".to_string(),
+                                    ),
+                                );
+                            };
+                            let Some(var_2) = var_2 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field status is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self {
+                                item: var_1,
+                                status: var_2,
+                            };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "GetItemResponse",
+                        }) + __protocol.struct_field_len(Some(1), &self.item)
+                            + __protocol.i32_field_len(Some(2), (&self.status).inner())
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // method to get an item
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+                pub struct TestServiceGetItemArgsSend {
+                    pub req: GetItemRequest,
+                }
+                impl ::pilota::thrift::Message for TestServiceGetItemArgsSend {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsSend",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_struct_field(
+                            1,
+                            &self.req,
+                            ::pilota::thrift::TType::Struct,
+                        )?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Struct =>
+                                    {
+                                        var_1 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsSend` field(#{}) failed, caused by: ", field_id));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field req is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { req: var_1 };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<GetItemRequest as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsSend` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field req is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self { req: var_1 };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsSend",
+                        }) + __protocol.struct_field_len(Some(1), &self.req)
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // GetItemRequest struct represents the request for getting an item
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+                pub struct GetItemRequest {
+                    pub id: i64,
+                }
+                impl ::pilota::thrift::Message for GetItemRequest {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "GetItemRequest",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_i64_field(1, *&self.id)?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::I64 =>
+                                    {
+                                        var_1 = Some(__protocol.read_i64()?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!(
+                                    "decode struct `GetItemRequest` field(#{}) failed, caused by: ",
+                                    field_id
+                                ));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field id is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { id: var_1 };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64  => {
+                    var_1 = Some(__protocol.read_i64().await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `GetItemRequest` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field id is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self { id: var_1 };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "GetItemRequest",
+                        }) + __protocol.i64_field_len(Some(1), *&self.id)
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
+                #[repr(transparent)]
+                pub struct Status(i32);
+
+                impl Status {
+                    pub const SUCCESS: Self = Self(0);
+                    pub const ERROR: Self = Self(1);
+
+                    pub fn inner(&self) -> i32 {
+                        self.0
+                    }
+
+                    pub fn to_string(&self) -> ::std::string::String {
+                        match self {
+                            Self(0) => ::std::string::String::from("SUCCESS"),
+                            Self(1) => ::std::string::String::from("ERROR"),
+                            Self(val) => val.to_string(),
+                        }
+                    }
+
+                    pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
+                        match value {
+                            0 => Some(Self::SUCCESS),
+                            1 => Some(Self::ERROR),
+                            _ => None,
+                        }
+                    }
+                }
+
+                impl ::std::convert::From<i32> for Status {
+                    fn from(value: i32) -> Self {
+                        Self(value)
+                    }
+                }
+
+                impl ::std::convert::From<Status> for i32 {
+                    fn from(value: Status) -> i32 {
+                        value.0
+                    }
+                }
+
+                impl ::pilota::thrift::Message for Status {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        __protocol.write_i32(self.inner())?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                        let value = __protocol.read_i32()?;
+                        ::std::result::Result::Ok(
+                            ::std::convert::TryFrom::try_from(value).map_err(|err| {
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    format!("invalid enum value for Status, value: {}", value),
+                                )
+                            })?,
+                        )
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let value = __protocol.read_i32().await?;
+                            ::std::result::Result::Ok(
+                                ::std::convert::TryFrom::try_from(value).map_err(|err| {
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        format!("invalid enum value for Status, value: {}", value),
+                                    )
+                                })?,
+                            )
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.i32_len(self.inner())
+                    }
+                }
+                pub trait TestService {}
+
+                // method to get an item
+
+                impl ::std::default::Default for TestServiceGetItemResultRecv {
+                    fn default() -> Self {
+                        TestServiceGetItemResultRecv::Ok(::std::default::Default::default())
+                    }
+                }
+                #[derive(Debug, Clone, PartialEq)]
+                pub enum TestServiceGetItemResultRecv {
+                    // method to get an item
+                    Ok(GetItemResponse),
+                }
+
+                impl ::pilota::thrift::Message for TestServiceGetItemResultRecv {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultRecv",
+                        })?;
+                        match self {
+                            TestServiceGetItemResultRecv::Ok(value) => {
+                                __protocol.write_struct_field(
+                                    0,
+                                    value,
+                                    ::pilota::thrift::TType::Struct,
+                                )?;
+                            }
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                        let mut ret = None;
+                        __protocol.read_struct_begin()?;
+                        loop {
+                            let field_ident = __protocol.read_field_begin()?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                __protocol.field_stop_len();
+                                break;
+                            } else {
+                                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                            }
+                            match field_ident.id {
+                                Some(0) => {
+                                    if ret.is_none() {
+                                        let field_ident =
+                                            ::pilota::thrift::Message::decode(__protocol)?;
+                                        __protocol.struct_len(&field_ident);
+                                        ret = Some(TestServiceGetItemResultRecv::Ok(field_ident));
+                                    } else {
+                                        return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                    }
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type)?;
+                                }
+                            }
+                        }
+                        __protocol.read_field_end()?;
+                        __protocol.read_struct_end()?;
+                        if let Some(ret) = ret {
+                            ::std::result::Result::Ok(ret)
+                        } else {
+                            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received empty union from remote Message",
+                            ))
+                        }
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut ret = None;
+                            __protocol.read_struct_begin().await?;
+                            loop {
+                                let field_ident = __protocol.read_field_begin().await?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    break;
+                                } else {
+                                }
+                                match field_ident.id {
+                                    Some(0) => {
+                                        if ret.is_none() {
+                                            let field_ident = <GetItemResponse as ::pilota::thrift::Message>::decode_async(__protocol).await?;
+
+                                            ret =
+                                                Some(TestServiceGetItemResultRecv::Ok(field_ident));
+                                        } else {
+                                            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                        }
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type).await?;
+                                    }
+                                }
+                            }
+                            __protocol.read_field_end().await?;
+                            __protocol.read_struct_end().await?;
+                            if let Some(ret) = ret {
+                                ::std::result::Result::Ok(ret)
+                            } else {
+                                ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received empty union from remote Message",
+                                    ),
+                                )
+                            }
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultRecv",
+                        }) + match self {
+                            TestServiceGetItemResultRecv::Ok(value) => {
+                                __protocol.struct_field_len(Some(0), value)
+                            }
+                        } + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift/comments.thrift
+++ b/pilota-build/test_data/thrift/comments.thrift
@@ -1,0 +1,46 @@
+namespace rs volo.rpc.example
+
+/*
+ * Item struct represents an item with id, title, content, and extra metadata
+ */
+
+// This is a comment for the Item struct
+struct Item {
+    // id of the item
+    1: required i64 id,
+    // title of the item
+
+    /*
+     * title of the item
+     */
+    2: required string title,
+    // content of the item
+    3: required string content,
+    // extra metadata of the item
+    10: optional map<string, string> extra,
+}
+
+// Status enum represents the status of an operation
+enum Status {
+    // Success status
+    SUCCESS = 0,
+    // Error status
+    ERROR = 1,
+}
+
+// GetItemRequest struct represents the request for getting an item
+struct GetItemRequest {
+    1: required i64 id,
+}
+
+// GetItemResponse struct represents the response for getting an item
+struct GetItemResponse {
+    1: required Item item,
+    2: required Status status,
+}
+
+// Test Service
+service TestService {
+    // method to get an item
+    GetItemResponse getItem(1: GetItemRequest req),
+}

--- a/pilota-build/test_data/thrift_workspace/output/common/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/common/src/gen.rs
@@ -529,6 +529,7 @@ pub mod r#gen {
 
             pub email: ::pilota::FastStr,
 
+            //4: required image.Image avatar,
             pub common_data: super::common::CommonData,
         }
         impl ::pilota::thrift::Message for Author {

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/loop/message_Article.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/loop/message_Article.rs
@@ -10,6 +10,7 @@ pub struct Article {
 
     pub status: Status,
 
+    //6: required list<image.Image> images,
     pub common_data: ::common::common::CommonData,
 }
 impl ::pilota::thrift::Message for Article {

--- a/pilota-thrift-parser/src/descriptor/constant.rs
+++ b/pilota-thrift-parser/src/descriptor/constant.rs
@@ -15,6 +15,7 @@ pub enum ConstValue {
 
 #[derive(Debug)]
 pub struct Constant {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub r#type: Type,
     pub value: ConstValue,

--- a/pilota-thrift-parser/src/descriptor/enum_.rs
+++ b/pilota-thrift-parser/src/descriptor/enum_.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 pub use super::{Annotations, Ident, IntConstant};
 
 #[derive(Debug)]
 pub struct EnumValue {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub value: Option<IntConstant>,
     pub annotations: Annotations,
@@ -9,6 +12,7 @@ pub struct EnumValue {
 
 #[derive(Debug)]
 pub struct Enum {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub values: Vec<EnumValue>,
     pub annotations: Annotations,

--- a/pilota-thrift-parser/src/descriptor/field.rs
+++ b/pilota-thrift-parser/src/descriptor/field.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::{Annotations, ConstValue, Ident, Type};
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -10,6 +12,7 @@ pub enum Attribute {
 
 #[derive(Debug, Clone)]
 pub struct Field {
+    pub comments: Arc<String>,
     pub id: i32,
     pub name: Ident,
     pub attribute: Attribute,

--- a/pilota-thrift-parser/src/descriptor/function.rs
+++ b/pilota-thrift-parser/src/descriptor/function.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use super::{Annotations, Field, Ident, Type};
 
 #[derive(Debug)]
 pub struct Function {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub oneway: bool,
     pub result_type: Type,

--- a/pilota-thrift-parser/src/descriptor/include.rs
+++ b/pilota-thrift-parser/src/descriptor/include.rs
@@ -1,9 +1,15 @@
+use std::sync::Arc;
+
 use super::Literal;
 
 #[derive(Debug)]
 pub struct Include {
+    pub comments: Arc<String>,
     pub path: Literal,
 }
 
 #[derive(Debug)]
-pub struct CppInclude(pub Literal);
+pub struct CppInclude {
+    pub comments: Arc<String>,
+    pub path: Literal,
+}

--- a/pilota-thrift-parser/src/descriptor/namespace.rs
+++ b/pilota-thrift-parser/src/descriptor/namespace.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{Annotations, Path};
 
 #[derive(Debug, Clone)]
@@ -5,6 +7,7 @@ pub struct Scope(pub String);
 
 #[derive(Debug, Clone)]
 pub struct Namespace {
+    pub comments: Arc<String>,
     pub scope: Scope,
     pub name: Path,
     pub annotations: Option<Annotations>,

--- a/pilota-thrift-parser/src/descriptor/service.rs
+++ b/pilota-thrift-parser/src/descriptor/service.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use super::{Annotations, Function, Ident, Path};
 
 #[derive(Debug)]
 pub struct Service {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub extends: Option<Path>,
     pub functions: Vec<Function>,

--- a/pilota-thrift-parser/src/descriptor/struct_.rs
+++ b/pilota-thrift-parser/src/descriptor/struct_.rs
@@ -1,22 +1,28 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use super::{Annotations, Field, Ident};
 
 #[derive(Debug)]
-pub struct Struct(pub StructLike);
+pub struct Struct {
+    pub comments: Arc<String>,
+    pub struct_like: StructLike,
+}
 
 macro_rules! struct_like {
     ($name: ty) => {
         impl Deref for $name {
             type Target = StructLike;
             fn deref(&self) -> &StructLike {
-                &self.0
+                &self.struct_like
             }
         }
 
         impl DerefMut for $name {
             fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.0
+                &mut self.struct_like
             }
         }
     };
@@ -25,12 +31,18 @@ macro_rules! struct_like {
 struct_like!(Struct);
 
 #[derive(Debug)]
-pub struct Union(pub StructLike);
+pub struct Union {
+    pub comments: Arc<String>,
+    pub struct_like: StructLike,
+}
 
 struct_like!(Union);
 
 #[derive(Debug)]
-pub struct Exception(pub StructLike);
+pub struct Exception {
+    pub comments: Arc<String>,
+    pub struct_like: StructLike,
+}
 
 struct_like!(Exception);
 

--- a/pilota-thrift-parser/src/descriptor/typedef.rs
+++ b/pilota-thrift-parser/src/descriptor/typedef.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use super::{Annotations, Ident, Type};
 
 #[derive(Debug)]
 pub struct Typedef {
+    pub comments: Arc<String>,
     pub r#type: Type,
     pub alias: Ident,
     pub annotations: Annotations,

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chumsky::prelude::*;
 
 use super::super::{
@@ -8,23 +10,37 @@ use crate::Literal;
 
 impl Include {
     pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
-        just("include")
-            .ignore_then(blank())
-            .ignore_then(Literal::parse())
+        comment()
+            .repeated()
+            .collect::<Vec<_>>()
+            .then_ignore(blank().or_not())
+            .then_ignore(just("include"))
+            .then_ignore(blank())
+            .then(Literal::parse())
             .then_ignore(blank().or_not())
             .then_ignore(list_separator().or_not())
-            .map(|path| Include { path })
+            .map(|(comments, path)| Include {
+                comments: Arc::new(comments.join("\n\n")),
+                path,
+            })
     }
 }
 
 impl CppInclude {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, CppInclude, extra::Err<Rich<'a, char>>> {
-        just("cpp_include")
-            .ignore_then(blank())
-            .ignore_then(Literal::parse())
+        comment()
+            .repeated()
+            .collect::<Vec<_>>()
+            .then_ignore(blank().or_not())
+            .then_ignore(just("cpp_include"))
+            .then_ignore(blank())
+            .then(Literal::parse())
             .then_ignore(blank().or_not())
             .then_ignore(list_separator().or_not())
-            .map(CppInclude)
+            .map(|(comments, path)| CppInclude {
+                comments: Arc::new(comments.join("\n\n")),
+                path,
+            })
     }
 }
 

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -44,21 +44,39 @@ pub fn list_separator<'a>() -> impl Parser<'a, &'a str, char, extra::Err<Rich<'a
 }
 
 pub fn blank<'a>() -> impl Parser<'a, &'a str, (), extra::Err<Rich<'a, char>>> {
+    one_of(" \t\r\n").repeated().ignored()
+}
+
+pub fn comment<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
     choice((
         just("//")
-            .then(any().and_is(just('\n').not()).repeated())
-            .ignored(),
+            .then(
+                any()
+                    .and_is(just('\n').not())
+                    .repeated()
+                    .collect::<String>(),
+            )
+            .then(just("\n").or_not())
+            .map(|((start, content), end)| format!("{}{}{}", start, content, end.unwrap_or("\n"))),
         just("#")
-            .then(any().and_is(just('\n').not()).repeated())
-            .ignored(),
+            .then(
+                any()
+                    .and_is(just('\n').not())
+                    .repeated()
+                    .collect::<String>(),
+            )
+            .then(just("\n").or_not())
+            .map(|((start, content), end)| format!("{}{}{}", start, content, end.unwrap_or("\n"))),
         just("/*")
-            .then(any().and_is(just("*/").not()).repeated())
+            .then(
+                any()
+                    .and_is(just("*/").not())
+                    .repeated()
+                    .collect::<String>(),
+            )
             .then(just("*/"))
-            .ignored(),
-        one_of(" \t\r\n").ignored(),
+            .map(|((start, content), end)| format!("{}{}{}", start, content, end)),
     ))
-    .repeated()
-    .ignored()
 }
 
 pub fn not_alphanumeric_or_underscore<'a>()

--- a/pilota-thrift-parser/src/parser/thrift.rs
+++ b/pilota-thrift-parser/src/parser/thrift.rs
@@ -398,6 +398,7 @@ enum Index {
     B,
 }
 
+// Test Service
 service TestService {
     Test test(1: TEST req);
 }"#;

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chumsky::prelude::*;
 
 use super::super::{descriptor::Typedef, parser::*};
@@ -5,13 +7,19 @@ use crate::{Annotation, Type, descriptor::Ident};
 
 impl Typedef {
     pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
-        just("typedef")
-            .ignore_then(Type::get_parser().padded_by(blank()))
+        comment()
+            .repeated()
+            .collect::<Vec<_>>()
+            .then_ignore(blank().or_not())
+            .then_ignore(just("typedef"))
+            .then_ignore(blank())
+            .then(Type::get_parser().padded_by(blank()))
             .then(Ident::get_parser())
             .then_ignore(blank().or_not())
             .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
-            .map(|((r#type, alias), annotations)| Typedef {
+            .map(|(((comments, r#type), alias), annotations)| Typedef {
+                comments: Arc::new(comments.join("\n\n")),
                 r#type,
                 alias: Ident(alias.into()),
                 annotations: annotations.unwrap_or_default(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

Currently, the Pilota build completely ignores comments in the user's IDL, which makes it harder for users to understand the meaning and usage of each field.
It is necessary to preserve all comments from the IDL in the generated code, including those for structs, enums, fields, services, methods, and types.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
